### PR TITLE
[Feat/#17] 관심 종목 등록 기능 구현

### DIFF
--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
 	testImplementation("org.springframework.batch:spring-batch-test")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 
-	// Spring Security + OAuth2 Client
+	// Security + OAuth2
 	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-oauth2-client")
 
@@ -42,8 +42,8 @@ dependencies {
 	implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.6")
 
 	// Redis
-	implementation ("org.springframework.boot:spring-boot-starter-data-redis")
-	implementation ("org.apache.commons:commons-pool2")
+	implementation("org.springframework.boot:spring-boot-starter-data-redis")
+	implementation("org.apache.commons:commons-pool2")
 
 	// JWT
 	implementation("io.jsonwebtoken:jjwt-api:0.11.5")
@@ -54,6 +54,12 @@ dependencies {
 	compileOnly("org.projectlombok:lombok")
 	annotationProcessor("org.projectlombok:lombok")
 
+	// QueryDSL
+	implementation("com.querydsl:querydsl-jpa:5.0.0:jakarta")
+	annotationProcessor("com.querydsl:querydsl-apt:5.0.0:jakarta")
+	annotationProcessor("jakarta.annotation:jakarta.annotation-api")
+	annotationProcessor("jakarta.persistence:jakarta.persistence-api")
+
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
 	testImplementation("org.springframework.security:spring-security-test")
 	testRuntimeOnly("org.junit.platform:junit-platform-launcher")
@@ -61,4 +67,17 @@ dependencies {
 
 tasks.withType<Test> {
 	useJUnitPlatform()
+}
+
+// QueryDSL Q-클래스 생성 경로
+val querydslDir = "build/generated/sources/annotationProcessor/java/main"
+
+tasks.withType<JavaCompile> {
+	options.annotationProcessorGeneratedSourcesDirectory = file(querydslDir)
+}
+
+sourceSets {
+	named("main") {
+		java.srcDir(querydslDir)
+	}
 }

--- a/backend/src/main/java/org/example/backend/domain/stock/controller/StockController.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/controller/StockController.java
@@ -3,6 +3,8 @@ package org.example.backend.domain.stock.controller;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.domain.stock.dto.response.StockResponse;
 import org.example.backend.domain.stock.service.StockService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -17,20 +19,20 @@ public class StockController {
 
     /** 기본 목록/검색: GET /api/stock?q= */
     @GetMapping
-    public ResponseEntity<List<StockResponse>> list(
-            @RequestParam(value = "keyword", required = false) String keyword
+    public ResponseEntity<Page<StockResponse>> list(
+            @RequestParam(value = "keyword", defaultValue = "") String keyword,
+            Pageable pageable
     ) {
-        List<StockResponse> responses =
-                (keyword == null || keyword.isBlank())
-                        ? stockService.getStocksAllOrderBySymbolAsc()
-                        : stockService.searchStocks(keyword);
-        return ResponseEntity.ok(responses);
+        Page<StockResponse> page = keyword.isBlank()
+                ? stockService.getStocksAllOrderBySymbolAsc(pageable)
+                : stockService.searchStocks(keyword.trim(), pageable);
+        return ResponseEntity.ok(page);
     }
 
     /** 랭킹(관심수 DESC): GET /api/stock/ranking */
     @GetMapping("/ranking")
-    public ResponseEntity<List<StockResponse>> ranking() {
-        return ResponseEntity.ok(stockService.getStocksRanking());
+    public ResponseEntity<Page<StockResponse>> ranking(Pageable pageable) {
+        return ResponseEntity.ok(stockService.getStocksRanking(pageable));
     }
 
     /** 단건 조회: GET /api/stock/{symbol} */

--- a/backend/src/main/java/org/example/backend/domain/stock/controller/StockController.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/controller/StockController.java
@@ -4,10 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.example.backend.domain.stock.dto.response.StockResponse;
 import org.example.backend.domain.stock.service.StockService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -18,20 +15,27 @@ public class StockController {
 
     private final StockService stockService;
 
-    /** 전체 종목 조회: GET /api/stock */
+    /** 기본 목록/검색: GET /api/stock?q= */
     @GetMapping
-    public ResponseEntity<List<StockResponse>> getAllStocks() {
-        List<StockResponse> responses = stockService.getStocksAll();
+    public ResponseEntity<List<StockResponse>> list(
+            @RequestParam(value = "keyword", required = false) String keyword
+    ) {
+        List<StockResponse> responses =
+                (keyword == null || keyword.isBlank())
+                        ? stockService.getStocksAllOrderBySymbolAsc()
+                        : stockService.searchStocks(keyword);
         return ResponseEntity.ok(responses);
     }
 
-    /** 단일 종목 조회: GET /api/stock/{symbol} */
-    @GetMapping("/{symbol}")
-    public ResponseEntity<StockResponse> getStock(
-            @PathVariable("symbol") String symbol
-    ) {
-        StockResponse response = stockService.getStockBySymbol(symbol);
-        return ResponseEntity.ok(response);
+    /** 랭킹(관심수 DESC): GET /api/stock/ranking */
+    @GetMapping("/ranking")
+    public ResponseEntity<List<StockResponse>> ranking() {
+        return ResponseEntity.ok(stockService.getStocksRanking());
     }
 
+    /** 단건 조회: GET /api/stock/{symbol} */
+    @GetMapping("/{symbol}")
+    public ResponseEntity<StockResponse> getStock(@PathVariable String symbol) {
+        return ResponseEntity.ok(stockService.getStockBySymbol(symbol));
+    }
 }

--- a/backend/src/main/java/org/example/backend/domain/stock/dto/response/StockResponse.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/dto/response/StockResponse.java
@@ -18,5 +18,8 @@ public record StockResponse(
         String market,
 
         @Schema(description = "ISIN 코드", example = "HK0000057197")
-        String isin
+        String isin,
+
+        @Schema(description = "관심 종목 수", example = "1234")
+        long watchCount
 ) { }

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/SpringDataStockRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/SpringDataStockRepository.java
@@ -1,15 +1,19 @@
 package org.example.backend.domain.stock.repository;
 
 import org.example.backend.domain.stock.entity.Stock;
+import org.example.backend.domain.stock.repository.query.StockQueryRepository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
 import java.util.Optional;
 
-public interface SpringDataStockRepository extends JpaRepository<Stock, Long> {
+public interface SpringDataStockRepository
+        extends JpaRepository<Stock, Long>, StockQueryRepository {
+
     Optional<Stock> findBySymbol(String symbol);
 
     @Query("select s.symbol from Stock s")
     List<String> findAllSymbols();
+
 }

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/StockRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/StockRepository.java
@@ -11,10 +11,11 @@ public interface StockRepository {
     Optional<Stock> findBySymbol(String symbol);
     List<Stock> findAll();
 
-    // 읽기 전용 쿼리 모델 (관심수 포함)
     List<StockResponse> findAllOrderByWatchCountDesc();
     Optional<StockResponse> findWithWatchCountBySymbol(String symbol);
 
+    List<StockResponse> findAllWithWatchCountOrderBySymbolAsc();
+    List<StockResponse> searchWithWatchCountByKeyword(String keyword);
     List<StockResponse> findWatchingStocksByUserId(Long userId);
 
     Stock save(Stock stock);

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/StockRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/StockRepository.java
@@ -2,6 +2,8 @@ package org.example.backend.domain.stock.repository;
 
 import org.example.backend.domain.stock.dto.response.StockResponse;
 import org.example.backend.domain.stock.entity.Stock;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
@@ -11,12 +13,12 @@ public interface StockRepository {
     Optional<Stock> findBySymbol(String symbol);
     List<Stock> findAll();
 
-    List<StockResponse> findAllOrderByWatchCountDesc();
+    Page<StockResponse> findAllOrderByWatchCountDesc(Pageable pageable);
     Optional<StockResponse> findWithWatchCountBySymbol(String symbol);
 
-    List<StockResponse> findAllWithWatchCountOrderBySymbolAsc();
-    List<StockResponse> searchWithWatchCountByKeyword(String keyword);
-    List<StockResponse> findWatchingStocksByUserId(Long userId);
+    Page<StockResponse> findAllWithWatchCountOrderBySymbolAsc(Pageable pageable);
+    Page<StockResponse> searchWithWatchCountByKeyword(String keyword, Pageable pageable);
+    Page<StockResponse> findWatchingStocksByUserId(Long userId, Pageable pageable);
 
     Stock save(Stock stock);
     List<Stock> saveAll(List<Stock> lists);

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/StockRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/StockRepository.java
@@ -1,16 +1,26 @@
 package org.example.backend.domain.stock.repository;
 
+import org.example.backend.domain.stock.dto.response.StockResponse;
 import org.example.backend.domain.stock.entity.Stock;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface StockRepository {
+    Optional<Stock> findById(Long id);
     Optional<Stock> findBySymbol(String symbol);
     List<Stock> findAll();
+
+    // 읽기 전용 쿼리 모델 (관심수 포함)
+    List<StockResponse> findAllOrderByWatchCountDesc();
+    Optional<StockResponse> findWithWatchCountBySymbol(String symbol);
+
+    List<StockResponse> findWatchingStocksByUserId(Long userId);
+
     Stock save(Stock stock);
     List<Stock> saveAll(List<Stock> lists);
     long count();
     void deleteAll();
     List<String> findAllSymbols();
+
 }

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/adapter/StockRepositoryAdapter.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/adapter/StockRepositoryAdapter.java
@@ -42,6 +42,16 @@ public class StockRepositoryAdapter implements StockRepository {
     }
 
     @Override
+    public List<StockResponse> findAllWithWatchCountOrderBySymbolAsc() {
+        return repository.findAllWithWatchCountOrderBySymbolAsc();
+    }
+
+    @Override
+    public List<StockResponse> searchWithWatchCountByKeyword(String keyword) {
+        return repository.searchWithWatchCountByKeyword(keyword);
+    }
+
+    @Override
     public List<StockResponse> findWatchingStocksByUserId(Long userId) {
         return repository.findWatchingStocksByUserId(userId);
     }

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/adapter/StockRepositoryAdapter.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/adapter/StockRepositoryAdapter.java
@@ -5,6 +5,8 @@ import org.example.backend.domain.stock.dto.response.StockResponse;
 import org.example.backend.domain.stock.entity.Stock;
 import org.example.backend.domain.stock.repository.SpringDataStockRepository;
 import org.example.backend.domain.stock.repository.StockRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -32,28 +34,28 @@ public class StockRepositoryAdapter implements StockRepository {
     }
 
     @Override
-    public List<StockResponse> findAllOrderByWatchCountDesc() {
-        return repository.findAllOrderByWatchCountDesc();
-    }
-
-    @Override
     public Optional<StockResponse> findWithWatchCountBySymbol(String symbol) {
         return repository.findWithWatchCountBySymbol(symbol);
     }
 
     @Override
-    public List<StockResponse> findAllWithWatchCountOrderBySymbolAsc() {
-        return repository.findAllWithWatchCountOrderBySymbolAsc();
+    public Page<StockResponse> findAllWithWatchCountOrderBySymbolAsc(Pageable pageable){
+        return repository.findAllWithWatchCountOrderBySymbolAsc(pageable);
     }
 
     @Override
-    public List<StockResponse> searchWithWatchCountByKeyword(String keyword) {
-        return repository.searchWithWatchCountByKeyword(keyword);
+    public Page<StockResponse> searchWithWatchCountByKeyword(String keyword, Pageable pageable){
+        return repository.searchWithWatchCountByKeyword(keyword, pageable);
     }
 
     @Override
-    public List<StockResponse> findWatchingStocksByUserId(Long userId) {
-        return repository.findWatchingStocksByUserId(userId);
+    public Page<StockResponse> findAllOrderByWatchCountDesc(Pageable pageable){
+        return repository.findAllOrderByWatchCountDesc(pageable);
+    }
+
+    @Override
+    public Page<StockResponse> findWatchingStocksByUserId(Long userId, Pageable pageable){
+        return repository.findWatchingStocksByUserId(userId, pageable);
     }
 
     @Override

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/adapter/StockRepositoryAdapter.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/adapter/StockRepositoryAdapter.java
@@ -1,6 +1,7 @@
 package org.example.backend.domain.stock.repository.adapter;
 
 import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.stock.dto.response.StockResponse;
 import org.example.backend.domain.stock.entity.Stock;
 import org.example.backend.domain.stock.repository.SpringDataStockRepository;
 import org.example.backend.domain.stock.repository.StockRepository;
@@ -16,6 +17,11 @@ public class StockRepositoryAdapter implements StockRepository {
     private final SpringDataStockRepository repository;
 
     @Override
+    public Optional<Stock> findById(Long id) { // (추가)
+        return repository.findById(id);
+    }
+
+    @Override
     public Optional<Stock> findBySymbol(String symbol) {
         return repository.findBySymbol(symbol);
     }
@@ -23,6 +29,21 @@ public class StockRepositoryAdapter implements StockRepository {
     @Override
     public List<Stock> findAll() {
         return repository.findAll();
+    }
+
+    @Override
+    public List<StockResponse> findAllOrderByWatchCountDesc() {
+        return repository.findAllOrderByWatchCountDesc();
+    }
+
+    @Override
+    public Optional<StockResponse> findWithWatchCountBySymbol(String symbol) {
+        return repository.findWithWatchCountBySymbol(symbol);
+    }
+
+    @Override
+    public List<StockResponse> findWatchingStocksByUserId(Long userId) {
+        return repository.findWatchingStocksByUserId(userId);
     }
 
     @Override

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/query/StockQueryRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/query/StockQueryRepository.java
@@ -1,15 +1,17 @@
 package org.example.backend.domain.stock.repository.query;
 
 import org.example.backend.domain.stock.dto.response.StockResponse;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 
 import java.util.List;
 import java.util.Optional;
 
 public interface StockQueryRepository {
 
-    List<StockResponse> findAllOrderByWatchCountDesc();
     Optional<StockResponse> findWithWatchCountBySymbol(String symbol);
-    List<StockResponse> findAllWithWatchCountOrderBySymbolAsc();
-    List<StockResponse> searchWithWatchCountByKeyword(String keyword);
-    List<StockResponse> findWatchingStocksByUserId(Long userId);
+    Page<StockResponse> findAllWithWatchCountOrderBySymbolAsc(Pageable pageable);
+    Page<StockResponse> searchWithWatchCountByKeyword(String keyword, Pageable pageable);
+    Page<StockResponse> findAllOrderByWatchCountDesc(Pageable pageable);
+    Page<StockResponse> findWatchingStocksByUserId(Long userId, Pageable pageable);
 }

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/query/StockQueryRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/query/StockQueryRepository.java
@@ -6,7 +6,10 @@ import java.util.List;
 import java.util.Optional;
 
 public interface StockQueryRepository {
+
     List<StockResponse> findAllOrderByWatchCountDesc();
     Optional<StockResponse> findWithWatchCountBySymbol(String symbol);
+    List<StockResponse> findAllWithWatchCountOrderBySymbolAsc();
+    List<StockResponse> searchWithWatchCountByKeyword(String keyword);
     List<StockResponse> findWatchingStocksByUserId(Long userId);
 }

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/query/StockQueryRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/query/StockQueryRepository.java
@@ -1,0 +1,12 @@
+package org.example.backend.domain.stock.repository.query;
+
+import org.example.backend.domain.stock.dto.response.StockResponse;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface StockQueryRepository {
+    List<StockResponse> findAllOrderByWatchCountDesc();
+    Optional<StockResponse> findWithWatchCountBySymbol(String symbol);
+    List<StockResponse> findWatchingStocksByUserId(Long userId);
+}

--- a/backend/src/main/java/org/example/backend/domain/stock/repository/query/StockQueryRepositoryImpl.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/repository/query/StockQueryRepositoryImpl.java
@@ -1,0 +1,69 @@
+package org.example.backend.domain.stock.repository.query;
+
+import com.querydsl.core.types.Projections;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.stock.dto.response.StockResponse;
+import org.example.backend.domain.stock.entity.QStock;
+import org.example.backend.domain.watch_list.entity.QWatchList;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+@RequiredArgsConstructor
+public class StockQueryRepositoryImpl implements StockQueryRepository {
+
+    private final JPAQueryFactory qf;
+
+    private final QStock s = QStock.stock;
+    private final QWatchList w = QWatchList.watchList;
+    private final QWatchList wUser = new QWatchList("wUser");
+
+    @Override
+    public List<StockResponse> findAllOrderByWatchCountDesc() {
+        return qf.select(Projections.constructor(
+                        StockResponse.class,
+                        s.id, s.symbol, s.name, s.market, s.isin,
+                        // 🔧 복합키라 단일 id 없음 → 사용자 id 기준으로 카운트
+                        w.user.id.count()
+                ))
+                .from(s)
+                .leftJoin(s.watchList, w)
+                .groupBy(s.id, s.symbol, s.name, s.market, s.isin)
+                .orderBy(w.user.id.count().desc())
+                .fetch();
+    }
+
+    @Override
+    public Optional<StockResponse> findWithWatchCountBySymbol(String symbol) {
+        return Optional.ofNullable(
+                qf.select(Projections.constructor(
+                                StockResponse.class,
+                                s.id, s.symbol, s.name, s.market, s.isin,
+                                w.user.id.count()
+                        ))
+                        .from(s)
+                        .leftJoin(s.watchList, w)
+                        .where(s.symbol.eq(symbol))
+                        .groupBy(s.id, s.symbol, s.name, s.market, s.isin)
+                        .fetchOne()
+        );
+    }
+
+    @Override
+    public List<StockResponse> findWatchingStocksByUserId(Long userId) {
+        return qf.select(Projections.constructor(
+                        StockResponse.class,
+                        s.id, s.symbol, s.name, s.market, s.isin,
+                        w.user.id.count() // 전체 관심수 집계
+                ))
+                .from(s)
+                .join(s.watchList, wUser).on(wUser.user.id.eq(userId)) // 내가 누른 것만
+                .leftJoin(s.watchList, w) // 전체 관심수 집계용
+                .groupBy(s.id, s.symbol, s.name, s.market, s.isin, wUser.createdAt)
+                .orderBy(wUser.createdAt.desc())
+                .fetch();
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/stock/service/StockService.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/service/StockService.java
@@ -5,14 +5,10 @@ import org.example.backend.domain.stock.dto.response.StockResponse;
 import org.example.backend.domain.stock.entity.Stock;
 import org.example.backend.domain.stock.repository.StockRepository;
 import org.example.backend.global.exception.stock.StockBySymbolNotFoundException;
-import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.ResponseStatusException;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
-import static org.example.backend.global.exception.ErrorCode.STOCK_BY_SYMBOL_NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -20,30 +16,20 @@ public class StockService {
 
     private final StockRepository stockRepository;
 
-    /** 전체 종목 조회 */
+    /** 전체 종목 조회 + 관심수 포함(내림차순) */
     public List<StockResponse> getStocksAll() {
-        List<Stock> stocks = stockRepository.findAll();
-        return stocks.stream()
-                .map(this::toResponse)
-                .collect(Collectors.toList());
+        return stockRepository.findAllOrderByWatchCountDesc();
     }
 
-    /** 단일 종목(symbol) 조회 */
+    /** 단일 종목(symbol) 조회 + 관심수 포함 */
     public StockResponse getStockBySymbol(String symbol) {
-        Stock stock = stockRepository.findBySymbol(symbol)
+        return stockRepository.findWithWatchCountBySymbol(symbol)
                 .orElseThrow(StockBySymbolNotFoundException::new);
-        return toResponse(stock);
     }
 
-    /** 엔티티 → DTO 변환 헬퍼 */
-    private StockResponse toResponse(Stock s) {
-        return new StockResponse(
-                s.getId(),
-                s.getSymbol(),
-                s.getName(),
-                s.getMarket(),
-                s.getIsin()
-        );
+    /** 내가 관심등록한 종목 리스트(최신순) + 각 항목 관심수 포함 */
+    public List<StockResponse> getMyWatchStocks(Long userId) {
+        return stockRepository.findWatchingStocksByUserId(userId);
     }
 }
 

--- a/backend/src/main/java/org/example/backend/domain/stock/service/StockService.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/service/StockService.java
@@ -5,6 +5,8 @@ import org.example.backend.domain.stock.dto.response.StockResponse;
 import org.example.backend.domain.stock.entity.Stock;
 import org.example.backend.domain.stock.repository.StockRepository;
 import org.example.backend.global.exception.stock.StockBySymbolNotFoundException;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -17,18 +19,18 @@ public class StockService {
     private final StockRepository stockRepository;
 
     /** 기본 목록(symbol ASC) */
-    public List<StockResponse> getStocksAllOrderBySymbolAsc() {
-        return stockRepository.findAllWithWatchCountOrderBySymbolAsc();
+    public Page<StockResponse> getStocksAllOrderBySymbolAsc(Pageable pageable) {
+        return stockRepository.findAllWithWatchCountOrderBySymbolAsc(pageable);
     }
 
     /** 종목 검색 */
-    public List<StockResponse> searchStocks(String keyword) {
-        return stockRepository.searchWithWatchCountByKeyword(keyword);
+    public Page<StockResponse> searchStocks(String q, Pageable pageable) {
+        return stockRepository.searchWithWatchCountByKeyword(q, pageable);
     }
 
     /** 랭킹(관심수 DESC) */
-    public List<StockResponse> getStocksRanking() {
-        return stockRepository.findAllOrderByWatchCountDesc();
+    public Page<StockResponse> getStocksRanking(Pageable pageable) {
+        return stockRepository.findAllOrderByWatchCountDesc(pageable);
     }
 
     /** 단일 종목(symbol) 조회 + 관심수 포함 */
@@ -38,8 +40,8 @@ public class StockService {
     }
 
     /** 내가 관심등록한 종목 리스트(최신순) + 각 항목 관심수 포함 */
-    public List<StockResponse> getMyWatchStocks(Long userId) {
-        return stockRepository.findWatchingStocksByUserId(userId);
+    public Page<StockResponse> getMyWatchStocks(Long userId, Pageable pageable) {
+        return stockRepository.findWatchingStocksByUserId(userId, pageable);
     }
 
 }

--- a/backend/src/main/java/org/example/backend/domain/stock/service/StockService.java
+++ b/backend/src/main/java/org/example/backend/domain/stock/service/StockService.java
@@ -16,8 +16,18 @@ public class StockService {
 
     private final StockRepository stockRepository;
 
-    /** 전체 종목 조회 + 관심수 포함(내림차순) */
-    public List<StockResponse> getStocksAll() {
+    /** 기본 목록(symbol ASC) */
+    public List<StockResponse> getStocksAllOrderBySymbolAsc() {
+        return stockRepository.findAllWithWatchCountOrderBySymbolAsc();
+    }
+
+    /** 종목 검색 */
+    public List<StockResponse> searchStocks(String keyword) {
+        return stockRepository.searchWithWatchCountByKeyword(keyword);
+    }
+
+    /** 랭킹(관심수 DESC) */
+    public List<StockResponse> getStocksRanking() {
         return stockRepository.findAllOrderByWatchCountDesc();
     }
 
@@ -31,5 +41,6 @@ public class StockService {
     public List<StockResponse> getMyWatchStocks(Long userId) {
         return stockRepository.findWatchingStocksByUserId(userId);
     }
+
 }
 

--- a/backend/src/main/java/org/example/backend/domain/watch_list/controller/WatchListController.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/controller/WatchListController.java
@@ -6,6 +6,8 @@ import org.example.backend.domain.stock.service.StockService;
 import org.example.backend.domain.watch_list.dto.response.WatchListResponse;
 import org.example.backend.domain.watch_list.service.WatchListService;
 import org.example.backend.global.jwt.custom.CustomUserDetails;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
@@ -62,10 +64,11 @@ public class WatchListController {
 
     /** 내 관심종목 리스트(최신순) + 각 항목 관심수 */
     @GetMapping("/me")
-    public ResponseEntity<List<StockResponse>> myList(
-            @AuthenticationPrincipal CustomUserDetails principal
+    public ResponseEntity<Page<StockResponse>> myList(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            Pageable pageable
     ) {
         Long userId = principal.getUser().getId();
-        return ResponseEntity.ok(stockService.getMyWatchStocks(userId));
+        return ResponseEntity.ok(stockService.getMyWatchStocks(userId, pageable));
     }
 }

--- a/backend/src/main/java/org/example/backend/domain/watch_list/controller/WatchListController.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/controller/WatchListController.java
@@ -1,0 +1,71 @@
+package org.example.backend.domain.watch_list.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.stock.dto.response.StockResponse;
+import org.example.backend.domain.stock.service.StockService;
+import org.example.backend.domain.watch_list.dto.response.WatchListResponse;
+import org.example.backend.domain.watch_list.service.WatchListService;
+import org.example.backend.global.jwt.custom.CustomUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/watchlist")
+@RequiredArgsConstructor
+public class WatchListController {
+
+    private final WatchListService watchListService;
+    private final StockService stockService;
+
+    /** 관심 등록 */
+    @PostMapping("/{symbol}")
+    public ResponseEntity<WatchListResponse> add(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable String symbol
+    ) {
+        Long userId = principal.getUser().getId();
+        return ResponseEntity.ok(watchListService.addWatch(userId, symbol));
+    }
+
+    /** 관심 해제 */
+    @DeleteMapping("/{symbol}")
+    public ResponseEntity<WatchListResponse> remove(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable String symbol
+    ) {
+        Long userId = principal.getUser().getId();
+        return ResponseEntity.ok(watchListService.removeWatch(userId, symbol));
+    }
+
+    /** 토글 */
+    @PostMapping("/{symbol}/toggle")
+    public ResponseEntity<WatchListResponse> toggle(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable String symbol
+    ) {
+        Long userId = principal.getUser().getId();
+        return ResponseEntity.ok(watchListService.toggleWatch(userId, symbol));
+    }
+
+    /** 단건 상태 확인 (watching + watchCount) */
+    @GetMapping("/{symbol}")
+    public ResponseEntity<WatchListResponse> state(
+            @AuthenticationPrincipal CustomUserDetails principal,
+            @PathVariable String symbol
+    ) {
+        Long userId = principal.getUser().getId();
+        return ResponseEntity.ok(watchListService.getWatchState(userId, symbol));
+    }
+
+    /** 내 관심종목 리스트(최신순) + 각 항목 관심수 */
+    @GetMapping("/me")
+    public ResponseEntity<List<StockResponse>> myList(
+            @AuthenticationPrincipal CustomUserDetails principal
+    ) {
+        Long userId = principal.getUser().getId();
+        return ResponseEntity.ok(stockService.getMyWatchStocks(userId));
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/watch_list/dto/response/WatchListResponse.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/dto/response/WatchListResponse.java
@@ -1,0 +1,17 @@
+package org.example.backend.domain.watch_list.dto.response;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "관심 종목 응답 DTO")
+public record WatchListResponse(
+
+        @Schema(description = "주식 코드", example = "900110")
+        String symbol,
+
+        @Schema(description = "현재 로그인한 사용자가 해당 종목을 관심종목으로 등록했는지 여부 (등록됨: true / 미등록: false)", example = "true")
+        boolean watching,
+
+        @Schema(description = "관심 종목 수", example = "1234")
+        long watchCount
+) {
+}

--- a/backend/src/main/java/org/example/backend/domain/watch_list/entity/WatchListId.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/entity/WatchListId.java
@@ -10,21 +10,10 @@ import java.util.Objects;
  */
 @NoArgsConstructor
 @AllArgsConstructor
+@EqualsAndHashCode
 public class WatchListId implements Serializable {
 
     private Long user;
     private Long stock;
 
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (o == null || getClass() != o.getClass()) return false;
-        WatchListId that = (WatchListId) o;
-        return Objects.equals(user, that.user) && Objects.equals(stock, that.stock);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(user, stock);
-    }
 }

--- a/backend/src/main/java/org/example/backend/domain/watch_list/repository/SpringDataWatchListRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/repository/SpringDataWatchListRepository.java
@@ -1,0 +1,21 @@
+package org.example.backend.domain.watch_list.repository;
+
+import org.example.backend.domain.watch_list.entity.WatchList;
+import org.example.backend.domain.watch_list.entity.WatchListId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface SpringDataWatchListRepository extends JpaRepository<WatchList, WatchListId> {
+
+    boolean existsByUserIdAndStockId(Long userId, Long stockId);
+
+    void deleteByUserIdAndStockId(Long userId, Long stockId);
+
+    long countByStockId(Long stockId);
+
+    List<WatchList> findByUserId(Long userId);
+
+    List<WatchList> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+}

--- a/backend/src/main/java/org/example/backend/domain/watch_list/repository/WatchListRepository.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/repository/WatchListRepository.java
@@ -1,0 +1,21 @@
+package org.example.backend.domain.watch_list.repository;
+
+import org.example.backend.domain.watch_list.entity.WatchList;
+import org.example.backend.domain.watch_list.entity.WatchListId;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface WatchListRepository {
+    boolean existsByUserIdAndStockId(Long userId, Long stockId);
+
+    void deleteByUserIdAndStockId(Long userId, Long stockId);
+
+    long countByStockId(Long stockId);
+
+    List<WatchList> findByUserId(Long userId);
+
+    List<WatchList> findByUserIdOrderByCreatedAtDesc(Long userId);
+
+    WatchList save(WatchList watchList);
+}

--- a/backend/src/main/java/org/example/backend/domain/watch_list/repository/adapter/WatchListRepositoryAdapter.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/repository/adapter/WatchListRepositoryAdapter.java
@@ -1,0 +1,46 @@
+package org.example.backend.domain.watch_list.repository.adapter;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.watch_list.entity.WatchList;
+import org.example.backend.domain.watch_list.entity.WatchListId;
+import org.example.backend.domain.watch_list.repository.SpringDataWatchListRepository;
+import org.example.backend.domain.watch_list.repository.WatchListRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class WatchListRepositoryAdapter implements WatchListRepository {
+    private final SpringDataWatchListRepository repository;
+
+    @Override
+    public boolean existsByUserIdAndStockId(Long userId, Long stockId) {
+        return repository.existsByUserIdAndStockId(userId, stockId);
+    }
+
+    @Override
+    public void deleteByUserIdAndStockId(Long userId, Long stockId) {
+        repository.deleteByUserIdAndStockId(userId, stockId);
+    }
+
+    @Override
+    public long countByStockId(Long stockId) {
+        return repository.countByStockId(stockId);
+    }
+
+    @Override
+    public List<WatchList> findByUserId(Long userId) {
+        return repository.findByUserId(userId);
+    }
+
+    @Override
+    public List<WatchList> findByUserIdOrderByCreatedAtDesc(Long userId) {
+        return repository.findByUserIdOrderByCreatedAtDesc(userId);
+    }
+
+    @Override
+    public WatchList save(WatchList watchList) {
+        return repository.save(watchList);
+    }
+}

--- a/backend/src/main/java/org/example/backend/domain/watch_list/service/WatchListService.java
+++ b/backend/src/main/java/org/example/backend/domain/watch_list/service/WatchListService.java
@@ -1,0 +1,96 @@
+package org.example.backend.domain.watch_list.service;
+
+import lombok.RequiredArgsConstructor;
+import org.example.backend.domain.stock.entity.Stock;
+import org.example.backend.domain.stock.repository.StockRepository;
+import org.example.backend.domain.user.entity.User;
+import org.example.backend.domain.user.service.UserService;
+import org.example.backend.domain.watch_list.dto.response.WatchListResponse;
+import org.example.backend.domain.watch_list.entity.WatchList;
+import org.example.backend.domain.watch_list.repository.WatchListRepository;
+import org.example.backend.global.exception.stock.StockBySymbolNotFoundException;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WatchListService {
+
+    private final WatchListRepository watchListRepository;
+    private final StockRepository stockRepository;
+    private final UserService userService;
+
+    /** 관심 등록 (idempotent) */
+    @Transactional
+    public WatchListResponse addWatch(Long userId, String symbol) {
+        Stock stock = stockRepository.findBySymbol(symbol)
+                .orElseThrow(StockBySymbolNotFoundException::new);
+        Long stockId = stock.getId();
+
+        if (!watchListRepository.existsByUserIdAndStockId(userId, stockId)) {
+            try {
+                WatchList wl = WatchList.builder()
+                        .user(User.builder().id(userId).build())
+                        .stock(stock)
+                        .build();
+                watchListRepository.save(wl);
+            } catch (DataIntegrityViolationException e) {
+                // 동시성으로 중복 insert 시 DB 유니크 제약에 걸리더라도 무시(idempotent)
+            }
+        }
+        long count = watchListRepository.countByStockId(stockId);
+        return new WatchListResponse(symbol, true, count);
+    }
+
+    /** 관심 해제 (idempotent) */
+    @Transactional
+    public WatchListResponse removeWatch(Long userId, String symbol) {
+        Stock stock = stockRepository.findBySymbol(symbol)
+                .orElseThrow(StockBySymbolNotFoundException::new);
+        Long stockId = stock.getId();
+
+        if (watchListRepository.existsByUserIdAndStockId(userId, stockId)) {
+            watchListRepository.deleteByUserIdAndStockId(userId, stockId);
+        }
+        long count = watchListRepository.countByStockId(stockId);
+        return new WatchListResponse(symbol, false, count);
+    }
+
+    /** 토글 */
+    @Transactional
+    public WatchListResponse toggleWatch(Long userId, String symbol) {
+        Stock stock = stockRepository.findBySymbol(symbol)
+                .orElseThrow(StockBySymbolNotFoundException::new);
+        Long stockId = stock.getId();
+
+        boolean exists = watchListRepository.existsByUserIdAndStockId(userId, stockId);
+        if (exists) {
+            watchListRepository.deleteByUserIdAndStockId(userId, stockId);
+        } else {
+            try {
+                WatchList wl = WatchList.builder()
+                        .user(User.builder().id(userId).build())
+                        .stock(stock)
+                        .build();
+                watchListRepository.save(wl);
+            } catch (DataIntegrityViolationException e) {
+                // 경합 시에도 일관되게 처리
+            }
+        }
+        long count = watchListRepository.countByStockId(stockId);
+        return new WatchListResponse(symbol, !exists, count);
+    }
+
+    /** 단건 상태 확인 */
+    @Transactional(readOnly = true)
+    public WatchListResponse getWatchState(Long userId, String symbol) {
+        Stock stock = stockRepository.findBySymbol(symbol)
+                .orElseThrow(StockBySymbolNotFoundException::new);
+        Long stockId = stock.getId();
+
+        boolean watching = watchListRepository.existsByUserIdAndStockId(userId, stockId);
+        long count = watchListRepository.countByStockId(stockId);
+        return new WatchListResponse(symbol, watching, count);
+    }
+}

--- a/backend/src/main/java/org/example/backend/global/config/QuerydslConfig.java
+++ b/backend/src/main/java/org/example/backend/global/config/QuerydslConfig.java
@@ -1,0 +1,14 @@
+package org.example.backend.global.config;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class QuerydslConfig {
+    @Bean
+    public JPAQueryFactory jpaQueryFactory(EntityManager em) {
+        return new JPAQueryFactory(em);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용
관심 종목 등록 기능 구현 (좋아요, 즐겨찾기와 같은 기능)

## ✅ To do
- [x] 프로젝트 계획 추가 (Jira)
- [x] API 명세서 작성
- [ ] 의존성 추가 (Querydsl)
- [ ] 관심 종목 수에 따른 정렬 기능 구현
- [ ] 키워드에 따른 종목 검색 기능 구현
- [x] 관심 종목 등록하는 기능 구현
- [x] 실시간 등록된 관심 종목 수 확인하는 기능 구현
- [x] 관심 등록한 종목을 내 정보에서 확인하는 기능 구현

