### PR TITLE
[Refactor/#43] 로그인/인증 리팩토링 및 보안 하드닝

### DIFF
--- a/.idea/dataSources.xml
+++ b/.idea/dataSources.xml
@@ -13,5 +13,17 @@
       </jdbc-additional-properties>
       <working-dir>$ProjectFileDir$</working-dir>
     </data-source>
+    <data-source source="LOCAL" name="0@localhost" uuid="f80f8dec-1921-460b-bc8d-e361bca6c251">
+      <driver-ref>redis</driver-ref>
+      <synchronize>true</synchronize>
+      <jdbc-driver>jdbc.RedisDriver</jdbc-driver>
+      <jdbc-url>jdbc:redis://localhost:6379/0</jdbc-url>
+      <jdbc-additional-properties>
+        <property name="com.intellij.clouds.kubernetes.db.host.port" />
+        <property name="com.intellij.clouds.kubernetes.db.enabled" value="false" />
+        <property name="com.intellij.clouds.kubernetes.db.container.port" />
+      </jdbc-additional-properties>
+      <working-dir>$ProjectFileDir$</working-dir>
+    </data-source>
   </component>
 </project>

--- a/backend/build.gradle.kts
+++ b/backend/build.gradle.kts
@@ -31,6 +31,9 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-webflux")
 	developmentOnly("org.springframework.boot:spring-boot-devtools")
 
+	implementation("net.bytebuddy:byte-buddy")
+	implementation("net.bytebuddy:byte-buddy-agent")
+
 	// kafka
 	implementation("org.springframework.kafka:spring-kafka")
 

--- a/backend/src/main/java/org/example/backend/global/config/SecurityConfig.java
+++ b/backend/src/main/java/org/example/backend/global/config/SecurityConfig.java
@@ -7,6 +7,7 @@ import org.example.backend.global.jwt.oauth2.*;
 import org.example.backend.type.RoleType;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.CsrfConfigurer;
@@ -52,9 +53,10 @@ public class SecurityConfig {
                 .formLogin(AbstractHttpConfigurer::disable)
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(AUTH_ALLOWLIST).permitAll()
-                        .requestMatchers(org.springframework.http.HttpMethod.OPTIONS, "/**").permitAll()
-                        .requestMatchers("/admin/**").hasAuthority(String.valueOf(RoleType.ROLE_ADMIN.name()))
-                        .requestMatchers("/api/**").hasAuthority(String.valueOf(RoleType.ROLE_USER.name()))
+                        .requestMatchers(HttpMethod.POST, "/api/auth/refresh").permitAll()
+                        .requestMatchers(HttpMethod.DELETE, "/api/auth/logout").hasAuthority(RoleType.ROLE_USER.name())
+                        .requestMatchers("/admin/**").hasAuthority(RoleType.ROLE_ADMIN.name())
+                        .requestMatchers("/api/**").hasAuthority(RoleType.ROLE_USER.name())
                         .anyRequest().authenticated())
                 .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .oauth2Login(oauth2 -> oauth2

--- a/backend/src/main/java/org/example/backend/global/jwt/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/org/example/backend/global/jwt/JwtAuthenticationFilter.java
@@ -23,7 +23,6 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.*;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -36,10 +35,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private static final String AUTHORIZATION_HEADER = HttpHeaders.AUTHORIZATION;
     private static final String BEARER_PREFIX = "Bearer ";
-
-    private static final Set<String> PUBLIC_PATH_PREFIXES = Set.of(
-            "/swagger-ui/", "/v3/", "/oauth2/", "/auth/", "/actuator/"
-    );
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,

--- a/backend/src/main/java/org/example/backend/global/jwt/oauth2/AuthController.java
+++ b/backend/src/main/java/org/example/backend/global/jwt/oauth2/AuthController.java
@@ -1,5 +1,6 @@
 package org.example.backend.global.jwt.oauth2;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.exception.auth.InvalidRefreshTokenException;
 import org.example.backend.global.jwt.JwtTokenProvider;
@@ -24,7 +25,7 @@ public class AuthController {
      */
     @PostMapping("/refresh")
     public ResponseEntity<TokenResponse> refresh(
-            @RequestBody TokenRequest request
+            @Valid @RequestBody TokenRequest request
     ) {
         String refreshToken = request.refreshToken();
 

--- a/backend/src/main/java/org/example/backend/global/jwt/oauth2/AuthController.java
+++ b/backend/src/main/java/org/example/backend/global/jwt/oauth2/AuthController.java
@@ -7,11 +7,14 @@ import org.example.backend.global.jwt.JwtTokenProvider;
 import org.example.backend.global.jwt.custom.CustomUserDetails;
 import org.example.backend.global.jwt.dto.request.TokenRequest;
 import org.example.backend.global.jwt.dto.response.TokenResponse;
+import org.example.backend.global.jwt.redis.RefreshSession;
 import org.example.backend.global.jwt.redis.TokenService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.web.bind.annotation.*;
+
+import java.util.Date;
 
 @RestController
 @RequestMapping("/api/auth")
@@ -20,53 +23,69 @@ public class AuthController {
     private final JwtTokenProvider jwtProvider;
     private final TokenService tokenService;
 
-    /**
-     * Refresh Token 검증 후 Access & Refresh Token 발급
-     */
     @PostMapping("/refresh")
-    public ResponseEntity<TokenResponse> refresh(
-            @Valid @RequestBody TokenRequest request
-    ) {
+    public ResponseEntity<TokenResponse> refresh(@Valid @RequestBody TokenRequest request) {
         String refreshToken = request.refreshToken();
 
-        // 1) 토큰 서명·만료·토큰타입 검증
+        // 1) 서명/만료/타입 검증
         if (!jwtProvider.validateRefreshToken(refreshToken)) {
             throw new InvalidRefreshTokenException();
         }
 
-        // 2) Redis에 저장된 토큰과 일치하는지 검증
-        String userId;
+        // 2) 클레임 추출
+        final String userId;
+        final String fam;
+        final String jti;
+        final Date   exp;
         try {
             userId = jwtProvider.getSubject(refreshToken);
-        } catch (JwtException exception) {
+            fam    = jwtProvider.getFamilyId(refreshToken);
+            jti    = jwtProvider.getJti(refreshToken);
+            exp    = jwtProvider.getExpiration(refreshToken);
+        } catch (JwtException e) {
             throw new InvalidRefreshTokenException();
         }
 
-        if (!tokenService.validateRefreshToken(userId, refreshToken)) {
+        long nowMs = System.currentTimeMillis();
+        long remainTtlMs = exp.getTime() - nowMs;
+
+        // 3) 블랙리스트 확인 (이미 회전된 RT 사용/가족 차단)
+        if (tokenService.isJtiBlacklisted(jti) || tokenService.isFamilyBlacklisted(fam)) {
             throw new InvalidRefreshTokenException();
         }
 
-        // 3) 새로운 토큰 발급
-        String accessToken = jwtProvider.generateAccessToken(userId);
-        String newRefreshToken = jwtProvider.generateRefreshToken(userId);
+        // 4) 서버 세션 상태 확인
+        RefreshSession session = tokenService.getSession(userId);
+        if (session == null) throw new InvalidRefreshTokenException();
 
-        // 4) Redis에 새 Refresh Token 저장
-        tokenService.storeRefreshToken(userId, newRefreshToken);
+        // 세션군(fam) 불일치 → 의심 시나리오 (장치가 다르거나 변조)
+        if (!fam.equals(session.familyId())) {
+            throw new InvalidRefreshTokenException();
+        }
 
-        // 5) 새 토큰 반환
-        return ResponseEntity.ok(new TokenResponse(accessToken, newRefreshToken));
+        // 5) 회전/재사용 분기
+        if (!jti.equals(session.currentJti())) {
+            // 재사용 탐지: 과거 RT 재제출
+            tokenService.blacklistReuseAndInvalidate(userId, fam, jti, remainTtlMs);
+            throw new InvalidRefreshTokenException();
+        }
+
+        // 정상: 회전 수행
+        String newAccessToken  = jwtProvider.generateAccessToken(userId, fam);
+        String newRefreshToken = jwtProvider.generateRefreshToken(userId, fam);
+        String newJti          = jwtProvider.getJti(newRefreshToken);
+
+        // 이전 jti 블랙리스트 + 세션 갱신
+        long newTtlMs = jwtProvider.getExpiration(newRefreshToken).getTime() - nowMs;
+        tokenService.rotate(userId, fam, jti, newJti, remainTtlMs, newTtlMs);
+
+        return ResponseEntity.ok(new TokenResponse(newAccessToken, newRefreshToken));
     }
 
-    /**
-     * 로그아웃: Redis에 저장된 Refresh Token 삭제
-     */
     @DeleteMapping("/logout")
-    public ResponseEntity<Void> logout(
-            @AuthenticationPrincipal CustomUserDetails principal
-    ) {
+    public ResponseEntity<Void> logout(@AuthenticationPrincipal CustomUserDetails principal) {
         String userId = principal.getUser().getId().toString();
-        tokenService.deleteRefreshToken(userId);
+        tokenService.deleteSession(userId);
         return ResponseEntity.noContent().build();
     }
-
 }

--- a/backend/src/main/java/org/example/backend/global/jwt/redis/RefreshSession.java
+++ b/backend/src/main/java/org/example/backend/global/jwt/redis/RefreshSession.java
@@ -1,0 +1,4 @@
+package org.example.backend.global.jwt.redis;
+
+public record RefreshSession(String familyId, String currentJti, long rotatedAt) { }
+

--- a/backend/src/main/java/org/example/backend/global/jwt/redis/TokenRepository.java
+++ b/backend/src/main/java/org/example/backend/global/jwt/redis/TokenRepository.java
@@ -21,7 +21,7 @@ public class TokenRepository {
     // RefreshToken을 사용자 식별값을 키로 하여 저장
     public void save(String userId, String refreshToken) {
         redisTemplate.opsForValue()
-                .set(keyOf(userId), refreshToken, Duration.ofDays(jwtProperties.getRefreshTokenExpirationMs()));     // 만료시간 설정 (7일)
+                .set(keyOf(userId), refreshToken, Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMs()));     // 만료시간 설정 (7일)
     }
 
     // 키로 저장된 리프레시 토큰 조회

--- a/backend/src/main/java/org/example/backend/global/jwt/redis/TokenRepository.java
+++ b/backend/src/main/java/org/example/backend/global/jwt/redis/TokenRepository.java
@@ -2,35 +2,116 @@ package org.example.backend.global.jwt.redis;
 
 import lombok.RequiredArgsConstructor;
 import org.example.backend.global.jwt.JwtProperties;
+import org.springframework.data.redis.connection.DataType;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
 
 @Repository
 @RequiredArgsConstructor
-// Redis 용 RefreshToken 저장소
 public class TokenRepository {
+
     private final StringRedisTemplate redisTemplate;
     private final JwtProperties jwtProperties;
 
-    private String keyOf(String userId) {
-        return "refresh:" + userId;
+    // === 키 프리픽스 ===
+    // 과거 단일 RT(String) 저장과 충돌을 원천 차단하려면 아래 SESSION_PREFIX를 "session:refresh:" 로 변경하고,
+    // 마이그레이션 기간 동안 구키를 읽어 새 포맷으로 저장 후 삭제하는 로직을 추가하세요.
+    private static final String SESSION_PREFIX = "refresh:";         // 과거와 동일 (타입 가드로 보호)
+    private static final String BL_RT_PREFIX   = "blacklist:rt:";
+    private static final String BL_FAM_PREFIX  = "blacklist:fam:";
+
+    private String keySession(String userId) { return SESSION_PREFIX + userId; }
+    private String keyRtBlacklist(String jti) { return BL_RT_PREFIX + jti; }
+    private String keyFamBlacklist(String fam) { return BL_FAM_PREFIX + fam; }
+
+    // === 내부 유틸: 키 타입 가드 ===
+    /** 해당 key가 HASH가 아니면(STRING/SET/… 또는 NONE 제외) 삭제하여 HMSET WRONGTYPE 방지 */
+    private void ensureHashKey(String key) {
+        DataType type = redisTemplate.type(key);
+        if (type != null && type != DataType.NONE && type != DataType.HASH) {
+            redisTemplate.delete(key);
+        }
     }
 
-    // RefreshToken을 사용자 식별값을 키로 하여 저장
-    public void save(String userId, String refreshToken) {
-        redisTemplate.opsForValue()
-                .set(keyOf(userId), refreshToken, Duration.ofMillis(jwtProperties.getRefreshTokenExpirationMs()));     // 만료시간 설정 (7일)
+    // === 세션 상태 저장/조회 (familyId/currentJti/rotatedAt) ===
+    public void saveSession(String userId, String familyId, String currentJti, long rotatedAtEpochMs, long ttlMs) {
+        String key = keySession(userId);
+
+        // 과거 문자열 키와 충돌 방지
+        ensureHashKey(key);
+
+        Map<String, String> map = new HashMap<>(4);
+        map.put("familyId", familyId);
+        map.put("currentJti", currentJti);
+        map.put("rotatedAt", String.valueOf(rotatedAtEpochMs));
+
+        redisTemplate.opsForHash().putAll(key, map);
+
+        if (ttlMs > 0) {
+            redisTemplate.expire(key, Duration.ofMillis(ttlMs));
+        }
     }
 
-    // 키로 저장된 리프레시 토큰 조회
-    public String findByKey(String userId) {
-        return redisTemplate.opsForValue().get(keyOf(userId));
+    public RefreshSession findSession(String userId) {
+        String key = keySession(userId);
+
+        // 읽기 시에도 타입 점검: HASH가 아니면 세션 없음으로 간주(과격 삭제 대신 보수적 처리)
+        DataType type = redisTemplate.type(key);
+        if (type == null || type == DataType.NONE) return null;
+        if (type != DataType.HASH) return null;
+
+        Object fam = redisTemplate.opsForHash().get(key, "familyId");
+        if (fam == null) return null;
+
+        String familyId   = Objects.toString(fam, null);
+        String currentJti = Objects.toString(redisTemplate.opsForHash().get(key, "currentJti"), null);
+        String rotatedAtStr = Objects.toString(redisTemplate.opsForHash().get(key, "rotatedAt"), "0");
+        long rotatedAt;
+        try {
+            rotatedAt = Long.parseLong(rotatedAtStr);
+        } catch (NumberFormatException e) {
+            rotatedAt = 0L;
+        }
+        return new RefreshSession(familyId, currentJti, rotatedAt);
     }
 
-    // 리프레시 토큰 삭제
-    public void delete(String userId) {
-        redisTemplate.delete(keyOf(userId));
+    public void deleteSession(String userId) {
+        redisTemplate.delete(keySession(userId));
+    }
+
+    // === 블랙리스트(String 타입) ===
+    public void blacklistJti(String jti, long ttlMs) {
+        if (jti == null) return;
+        if (ttlMs > 0) {
+            redisTemplate.opsForValue().set(keyRtBlacklist(jti), "1", Duration.ofMillis(ttlMs));
+        } else {
+            redisTemplate.opsForValue().set(keyRtBlacklist(jti), "1");
+        }
+    }
+
+    public boolean isJtiBlacklisted(String jti) {
+        if (jti == null) return false;
+        Boolean exists = redisTemplate.hasKey(keyRtBlacklist(jti));
+        return exists != null && exists;
+    }
+
+    public void blacklistFamily(String fam, long ttlMs) {
+        if (fam == null) return;
+        if (ttlMs > 0) {
+            redisTemplate.opsForValue().set(keyFamBlacklist(fam), "1", Duration.ofMillis(ttlMs));
+        } else {
+            redisTemplate.opsForValue().set(keyFamBlacklist(fam), "1");
+        }
+    }
+
+    public boolean isFamilyBlacklisted(String fam) {
+        if (fam == null) return false;
+        Boolean exists = redisTemplate.hasKey(keyFamBlacklist(fam));
+        return exists != null && exists;
     }
 }

--- a/backend/src/main/java/org/example/backend/global/jwt/redis/TokenService.java
+++ b/backend/src/main/java/org/example/backend/global/jwt/redis/TokenService.java
@@ -1,29 +1,43 @@
 package org.example.backend.global.jwt.redis;
 
 import lombok.RequiredArgsConstructor;
+import org.example.backend.global.jwt.JwtProperties;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
-// RefreshToken 관리 서비스
 public class TokenService {
 
-    private final TokenRepository tokenRepository;
+    private final TokenRepository repo;
+    private final JwtProperties props;
 
-    // 사용자별 리프레시 토큰 저장
-    public void storeRefreshToken(String userIdKey, String refreshToken) {
-        tokenRepository.save(userIdKey, refreshToken);
+    // 신규/최초 세션 저장(로그인 시)
+    public void initSession(String userId, String familyId, String currentJti) {
+        repo.saveSession(userId, familyId, currentJti, System.currentTimeMillis(),
+                props.getRefreshTokenExpirationMs());
     }
 
-    // 토큰 유효성 검사 (Redis에 저장된 토큰과 일치하는지 확인)
-    public boolean validateRefreshToken(String userIdKey, String refreshToken) {
-        String storedToken = tokenRepository.findByKey(userIdKey);
-        if(storedToken == null) return false;
-        return refreshToken.equals(storedToken);
+    public RefreshSession getSession(String userId) {
+        return repo.findSession(userId);
     }
 
-    // 리프레시 토큰 삭제 (로그아웃 또는 재발급 시 사용)
-    public void deleteRefreshToken(String username) {
-        tokenRepository.delete(username);
+    public void rotate(String userId, String familyId, String oldJti, String newJti, long oldTtlMs, long newTtlMs) {
+        // 이전 jti 블랙리스트(남은 TTL 만큼)
+        repo.blacklistJti(oldJti, Math.max(oldTtlMs, 0));
+        // 새 jti로 세션 갱신
+        repo.saveSession(userId, familyId, newJti, System.currentTimeMillis(), newTtlMs);
     }
+
+    public void blacklistReuseAndInvalidate(String userId, String familyId, String jti, long ttlMs) {
+        // 재사용된 jti 블랙리스트 + 해당 세션군 차단(선택)
+        repo.blacklistJti(jti, Math.max(ttlMs, 0));
+        repo.blacklistFamily(familyId, Math.max(ttlMs, 0)); // 선택: fam 차단
+        // 세션 삭제(해당 세션군 강제 로그아웃 효과)
+        repo.deleteSession(userId);
+    }
+
+    public boolean isJtiBlacklisted(String jti) { return repo.isJtiBlacklisted(jti); }
+    public boolean isFamilyBlacklisted(String fam) { return repo.isFamilyBlacklisted(fam); }
+
+    public void deleteSession(String userId) { repo.deleteSession(userId); }
 }


### PR DESCRIPTION
## ⚠️ Issue
로그인/인증 리팩토링 및 보안 하드닝

### 배경
- `/api/**` 권한 정책으로 `POST /api/auth/refresh`가 401 발생 가능
- `TokenRequest`의 `@NotBlank`가 `@Valid` 누락으로 미검증
- Refresh TTL 단위 버그(`ofDays` vs ms)
- URL 쿼리스트링으로 토큰 전달(민감정보 노출 위험)
- Refresh 재사용 공격 방어 미흡(토큰 롤링 없음)

## ✅ To do
- [x] `/api/auth/refresh` 화이트리스트 추가 (`permitAll`)
- [x] `AuthController.refresh()`에 `@Valid` 추가
- [x] Redis TTL 단위 수정: `Duration.ofMillis(refreshTokenExpirationMs)`
- [x] Refresh 토큰 롤링/재사용 탐지 도입 (fam/jti/blacklist 설계, Redis 키 추가)
